### PR TITLE
Fix tests after Sentry\State\Scope::getBreadcrumbs() were removed

### DIFF
--- a/tests/BreadcrumbsHandlerTest.php
+++ b/tests/BreadcrumbsHandlerTest.php
@@ -6,6 +6,7 @@ namespace Fmasa\SentryBreadcrumbsMonologHandler;
 
 use Monolog\Logger;
 use PHPUnit\Framework\TestCase;
+use Sentry\Event;
 use Sentry\State\HubInterface;
 use Sentry\State\Scope;
 
@@ -42,7 +43,11 @@ final class BreadcrumbsHandlerTest extends TestCase
 
         $this->handler->handle($record);
 
-        $breadcrumbs = $this->scope->getBreadcrumbs();
+        $event = new Event();
+
+        $this->scope->applyToEvent($event, []);
+
+        $breadcrumbs = $event->getBreadcrumbs();
 
         $this->assertCount(1, $breadcrumbs);
         $this->assertSame($record['message'], $breadcrumbs[0]->getMessage());


### PR DESCRIPTION
This method was removed (after being marked as internal before) in
https://github.com/getsentry/sentry-php/commit/2052a04dd4821cd8503dca18f0360d55f7e48e58