### PR TITLE
Use the channel for the breadcrumb category

### DIFF
--- a/src/SentryBreadcrumbsMonologHandler/BreadcrumbsHandler.php
+++ b/src/SentryBreadcrumbsMonologHandler/BreadcrumbsHandler.php
@@ -42,7 +42,7 @@ final class BreadcrumbsHandler extends AbstractProcessingHandler
                 new Breadcrumb(
                     $this->convertMonologLevelToSentryLevel($record['level']),
                     Breadcrumb::TYPE_DEFAULT,
-                    'default',
+                    $record['channel'],
                     $record['message'],
                     $record['context'] ?? null
                 )

--- a/tests/BreadcrumbsHandlerTest.php
+++ b/tests/BreadcrumbsHandlerTest.php
@@ -37,6 +37,7 @@ final class BreadcrumbsHandlerTest extends TestCase
     {
         $record = [
             'message' => 'Test message',
+            'channel' => 'app',
             'level' => Logger::WARNING,
             'context' => ['option' => 'value'],
             'extra' => [],
@@ -54,6 +55,7 @@ final class BreadcrumbsHandlerTest extends TestCase
         $this->assertSame($record['message'], $breadcrumbs[0]->getMessage());
         $this->assertSame($record['context'], $breadcrumbs[0]->getMetadata());
         $this->assertSame('default', $breadcrumbs[0]->getType());
+        $this->assertSame('app', $breadcrumbs[0]->getCategory());
     }
 
     protected function tearDown() : void


### PR DESCRIPTION
Currently the category is hardcoded to `default`. This pull requests changes the default value and uses the channel name for the category, to provide a bit more context.