### PR TITLE
Add support for Sentry 3.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     },
     "require": {
         "php": ">=7.1",
-        "sentry/sentry": "^2.1",
+        "sentry/sentry": "^2.1|^3.0",
         "monolog/monolog": "^1.2|^2.0"
     },
     "require-dev": {

--- a/src/SentryBreadcrumbsMonologHandler/BreadcrumbsHandler.php
+++ b/src/SentryBreadcrumbsMonologHandler/BreadcrumbsHandler.php
@@ -9,18 +9,18 @@ use Monolog\Logger;
 use Sentry\Breadcrumb;
 use Sentry\State\HubInterface;
 use Sentry\State\Scope;
+use function defined;
 
 final class BreadcrumbsHandler extends AbstractProcessingHandler
 {
-    private const LEVELS = [
+    /** @var array<string, string> */
+    private static $levels = [
         Logger::DEBUG => Breadcrumb::LEVEL_DEBUG,
         Logger::INFO => Breadcrumb::LEVEL_INFO,
         Logger::NOTICE => Breadcrumb::LEVEL_INFO,
         Logger::WARNING => Breadcrumb::LEVEL_WARNING,
         Logger::ERROR => Breadcrumb::LEVEL_ERROR,
-        Logger::CRITICAL => Breadcrumb::LEVEL_CRITICAL,
-        Logger::ALERT => Breadcrumb::LEVEL_CRITICAL,
-        Logger::EMERGENCY => Breadcrumb::LEVEL_CRITICAL,
+        // Logger::CRITICAL, Logger::ALERT and Logger::EMERGENCY are set in the constructor
     ];
 
     /** @var HubInterface */
@@ -30,6 +30,11 @@ final class BreadcrumbsHandler extends AbstractProcessingHandler
     {
         parent::__construct();
         $this->hub = $hub;
+
+        $criticalLevel                   = defined(Breadcrumb::class . '::LEVEL_FATAL') ? Breadcrumb::LEVEL_FATAL : Breadcrumb::LEVEL_CRITICAL;
+        self::$levels[Logger::CRITICAL]  = $criticalLevel;
+        self::$levels[Logger::ALERT]     = $criticalLevel;
+        self::$levels[Logger::EMERGENCY] = $criticalLevel;
     }
 
     /**
@@ -57,6 +62,6 @@ final class BreadcrumbsHandler extends AbstractProcessingHandler
      */
     private function convertMonologLevelToSentryLevel(int $level) : string
     {
-        return self::LEVELS[$level] ?? Breadcrumb::LEVEL_INFO;
+        return self::$levels[$level] ?? Breadcrumb::LEVEL_INFO;
     }
 }

--- a/tests/BreadcrumbsHandlerTest.php
+++ b/tests/BreadcrumbsHandlerTest.php
@@ -7,9 +7,12 @@ namespace Fmasa\SentryBreadcrumbsMonologHandler;
 use Mockery;
 use Monolog\Logger;
 use PHPUnit\Framework\TestCase;
+use Sentry\Breadcrumb;
 use Sentry\Event;
 use Sentry\State\HubInterface;
 use Sentry\State\Scope;
+use function defined;
+use function method_exists;
 
 final class BreadcrumbsHandlerTest extends TestCase
 {
@@ -43,19 +46,53 @@ final class BreadcrumbsHandlerTest extends TestCase
             'extra' => [],
         ];
 
-        $this->handler->handle($record);
-
-        $event = new Event();
-
-        $this->scope->applyToEvent($event, []);
-
-        $breadcrumbs = $event->getBreadcrumbs();
+        $breadcrumbs = $this->handleRecord($record);
 
         $this->assertCount(1, $breadcrumbs);
         $this->assertSame($record['message'], $breadcrumbs[0]->getMessage());
         $this->assertSame($record['context'], $breadcrumbs[0]->getMetadata());
         $this->assertSame('default', $breadcrumbs[0]->getType());
         $this->assertSame('app', $breadcrumbs[0]->getCategory());
+    }
+
+    public function testWriteRecordSetsCorrectLevel() : void
+    {
+        $record = [
+            'message' => 'Test message',
+            'channel' => 'app',
+            'level' => Logger::ALERT,
+            'context' => [],
+            'extra' => [],
+        ];
+
+        $expectedLevel = defined(Breadcrumb::class . '::LEVEL_FATAL') ? 'fatal' : 'critical';
+
+        $breadcrumbs = $this->handleRecord($record);
+
+        $this->assertCount(1, $breadcrumbs);
+        $this->assertSame($expectedLevel, $breadcrumbs[0]->getLevel());
+    }
+
+    /**
+     * @param array<string, mixed> $record
+     *
+     * @return Breadcrumb[]
+     */
+    private function handleRecord(array $record) : array
+    {
+        $this->handler->handle($record);
+
+        if (method_exists(Event::class, 'createEvent')) {
+            // Sentry 3
+            $event = Event::createEvent();
+            $this->scope->applyToEvent($event);
+        } else {
+            // Sentry 2
+            $event = new Event();
+            $this->scope->applyToEvent($event, []);
+        }
+
+        return $event->getBreadcrumbs();
     }
 
     protected function tearDown() : void


### PR DESCRIPTION
This pull request adds support for the new sentry/sentry 3.x.

The main change is the error level `Breadcrumb::LEVEL_FATAL` instead of `Breadcrumb::LEVEL_CRITICAL`.